### PR TITLE
Add favorites: heart toggle on details and a Favorites screen

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -115,6 +115,8 @@ dependencies {
     kapt "androidx.room:room-compiler:$room_version"
 
     testImplementation "junit:junit:$test_junit_version"
+    testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:$coroutines_version"
+    testImplementation "androidx.arch.core:core-testing:2.2.0"
     androidTestImplementation "androidx.test.ext:junit:$androidTest_junit_version"
     androidTestImplementation "androidx.test.espresso:espresso-core:$androidTest_espresso_version"
 }

--- a/app/src/main/java/com/example/android/dogsapp/BindingAdapters.kt
+++ b/app/src/main/java/com/example/android/dogsapp/BindingAdapters.kt
@@ -50,6 +50,14 @@ fun bindStatus(statusImageView: ImageView, status: DogsApiStatus?) {
     }
 }
 
+@BindingAdapter("isFavorite")
+fun bindFavoriteIcon(view: ImageView, isFavorite: Boolean?) {
+    view.setImageResource(
+        if (isFavorite == true) R.drawable.ic_favorite_filled
+        else R.drawable.ic_favorite_border
+    )
+}
+
 @SuppressLint("SetTextI18n")
 @BindingAdapter("breedName")
 fun bindBreedName(textView: TextView, imageUrl: String?) {

--- a/app/src/main/java/com/example/android/dogsapp/common/di/application/ApplicationModule.kt
+++ b/app/src/main/java/com/example/android/dogsapp/common/di/application/ApplicationModule.kt
@@ -5,6 +5,8 @@ import androidx.room.Room
 import com.example.android.dogsapp.DogsApplication
 import com.example.android.dogsapp.data.local.DogDao
 import com.example.android.dogsapp.data.local.DogsDatabase
+import com.example.android.dogsapp.data.local.FavoriteDao
+import com.example.android.dogsapp.data.local.MIGRATION_1_2
 import com.example.android.dogsapp.data.network.DogsApi
 import com.example.android.dogsapp.data.repository.DogsRepository
 import com.example.android.dogsapp.data.repository.DogsRepositoryImpl
@@ -56,14 +58,23 @@ object ApplicationModule {
     @Singleton
     @Provides
     fun provideDogsDatabase(@ApplicationContext context: Context): DogsDatabase =
-        Room.databaseBuilder(context, DogsDatabase::class.java, DATABASE_NAME).build()
+        Room.databaseBuilder(context, DogsDatabase::class.java, DATABASE_NAME)
+            .addMigrations(MIGRATION_1_2)
+            .build()
 
     @Provides
     fun provideDogDao(database: DogsDatabase): DogDao = database.dogDao()
 
     @Provides
-    fun provideDogsRepository(dogsApi: DogsApi, dogDao: DogDao): DogsRepository {
-        return DogsRepositoryImpl(dogsApi, dogDao)
+    fun provideFavoriteDao(database: DogsDatabase): FavoriteDao = database.favoriteDao()
+
+    @Provides
+    fun provideDogsRepository(
+        dogsApi: DogsApi,
+        dogDao: DogDao,
+        favoriteDao: FavoriteDao,
+    ): DogsRepository {
+        return DogsRepositoryImpl(dogsApi, dogDao, favoriteDao)
     }
 
     @Provides

--- a/app/src/main/java/com/example/android/dogsapp/data/local/DogsDatabase.kt
+++ b/app/src/main/java/com/example/android/dogsapp/data/local/DogsDatabase.kt
@@ -2,8 +2,20 @@ package com.example.android.dogsapp.data.local
 
 import androidx.room.Database
 import androidx.room.RoomDatabase
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
 
-@Database(entities = [DogEntity::class], version = 1, exportSchema = false)
+@Database(entities = [DogEntity::class, FavoriteEntity::class], version = 2, exportSchema = false)
 abstract class DogsDatabase : RoomDatabase() {
     abstract fun dogDao(): DogDao
+    abstract fun favoriteDao(): FavoriteDao
+}
+
+val MIGRATION_1_2 = object : Migration(1, 2) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        db.execSQL(
+            "CREATE TABLE IF NOT EXISTS `favorites` " +
+                "(`imageUrl` TEXT NOT NULL, PRIMARY KEY(`imageUrl`))"
+        )
+    }
 }

--- a/app/src/main/java/com/example/android/dogsapp/data/local/FavoriteDao.kt
+++ b/app/src/main/java/com/example/android/dogsapp/data/local/FavoriteDao.kt
@@ -1,0 +1,26 @@
+package com.example.android.dogsapp.data.local
+
+import androidx.lifecycle.LiveData
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+
+@Dao
+interface FavoriteDao {
+
+    @Query("SELECT * FROM favorites ORDER BY imageUrl")
+    fun observeFavorites(): LiveData<List<FavoriteEntity>>
+
+    @Query("SELECT EXISTS(SELECT 1 FROM favorites WHERE imageUrl = :imageUrl)")
+    fun isFavorite(imageUrl: String): LiveData<Boolean>
+
+    @Query("SELECT EXISTS(SELECT 1 FROM favorites WHERE imageUrl = :imageUrl)")
+    suspend fun isFavoriteOnce(imageUrl: String): Boolean
+
+    @Insert(onConflict = OnConflictStrategy.IGNORE)
+    suspend fun add(favorite: FavoriteEntity)
+
+    @Query("DELETE FROM favorites WHERE imageUrl = :imageUrl")
+    suspend fun remove(imageUrl: String)
+}

--- a/app/src/main/java/com/example/android/dogsapp/data/local/FavoriteEntity.kt
+++ b/app/src/main/java/com/example/android/dogsapp/data/local/FavoriteEntity.kt
@@ -1,0 +1,9 @@
+package com.example.android.dogsapp.data.local
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "favorites")
+data class FavoriteEntity(
+    @PrimaryKey val imageUrl: String,
+)

--- a/app/src/main/java/com/example/android/dogsapp/data/repository/DogsRepository.kt
+++ b/app/src/main/java/com/example/android/dogsapp/data/repository/DogsRepository.kt
@@ -5,5 +5,8 @@ import com.example.android.dogsapp.data.domain.Dog
 
 interface DogsRepository {
     val dogs: LiveData<List<Dog>>
+    val favorites: LiveData<List<Dog>>
+    fun isFavorite(imageUrl: String): LiveData<Boolean>
+    suspend fun toggleFavorite(imageUrl: String)
     suspend fun refresh()
 }

--- a/app/src/main/java/com/example/android/dogsapp/data/repository/DogsRepositoryImpl.kt
+++ b/app/src/main/java/com/example/android/dogsapp/data/repository/DogsRepositoryImpl.kt
@@ -5,16 +5,34 @@ import androidx.lifecycle.map
 import com.example.android.dogsapp.data.domain.Dog
 import com.example.android.dogsapp.data.local.DogDao
 import com.example.android.dogsapp.data.local.DogEntity
+import com.example.android.dogsapp.data.local.FavoriteDao
+import com.example.android.dogsapp.data.local.FavoriteEntity
 import com.example.android.dogsapp.data.network.DogsApi
 import javax.inject.Inject
 
 class DogsRepositoryImpl @Inject constructor(
     private val dogsApi: DogsApi,
     private val dogDao: DogDao,
+    private val favoriteDao: FavoriteDao,
 ) : DogsRepository {
 
     override val dogs: LiveData<List<Dog>> = dogDao.observeDogs().map { entities ->
         entities.map { Dog(it.imageUrl) }
+    }
+
+    override val favorites: LiveData<List<Dog>> = favoriteDao.observeFavorites().map { entities ->
+        entities.map { Dog(it.imageUrl) }
+    }
+
+    override fun isFavorite(imageUrl: String): LiveData<Boolean> =
+        favoriteDao.isFavorite(imageUrl)
+
+    override suspend fun toggleFavorite(imageUrl: String) {
+        if (favoriteDao.isFavoriteOnce(imageUrl)) {
+            favoriteDao.remove(imageUrl)
+        } else {
+            favoriteDao.add(FavoriteEntity(imageUrl))
+        }
     }
 
     override suspend fun refresh() {

--- a/app/src/main/java/com/example/android/dogsapp/ui/details/DetailsFragment.kt
+++ b/app/src/main/java/com/example/android/dogsapp/ui/details/DetailsFragment.kt
@@ -5,11 +5,15 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
 import com.example.android.dogsapp.databinding.FragmentDetailsBinding
+import dagger.hilt.android.AndroidEntryPoint
 
+@AndroidEntryPoint
 class DetailsFragment : Fragment() {
 
     private lateinit var binding: FragmentDetailsBinding
+    private val viewModel: DetailsViewModel by viewModels()
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
@@ -17,10 +21,8 @@ class DetailsFragment : Fragment() {
     ): View {
         binding = FragmentDetailsBinding.inflate(inflater, container, false)
         binding.lifecycleOwner = viewLifecycleOwner
-
-        val dogDetails = DetailsFragmentArgs.fromBundle(requireArguments()).dog
-
-        binding.dog = dogDetails
+        binding.dog = viewModel.dog
+        binding.viewModel = viewModel
 
         return binding.root
     }

--- a/app/src/main/java/com/example/android/dogsapp/ui/details/DetailsViewModel.kt
+++ b/app/src/main/java/com/example/android/dogsapp/ui/details/DetailsViewModel.kt
@@ -1,0 +1,30 @@
+package com.example.android.dogsapp.ui.details
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.android.dogsapp.data.domain.Dog
+import com.example.android.dogsapp.data.repository.DogsRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class DetailsViewModel @Inject constructor(
+    private val dogsRepository: DogsRepository,
+    savedStateHandle: SavedStateHandle,
+) : ViewModel() {
+
+    val dog: Dog = checkNotNull(savedStateHandle["dog"]) {
+        "Missing 'dog' nav argument"
+    }
+
+    val isFavorite: LiveData<Boolean> = dogsRepository.isFavorite(dog.imageUrl)
+
+    fun toggleFavorite() {
+        viewModelScope.launch {
+            dogsRepository.toggleFavorite(dog.imageUrl)
+        }
+    }
+}

--- a/app/src/main/java/com/example/android/dogsapp/ui/favorites/FavoritesFragment.kt
+++ b/app/src/main/java/com/example/android/dogsapp/ui/favorites/FavoritesFragment.kt
@@ -1,0 +1,49 @@
+package com.example.android.dogsapp.ui.favorites
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
+import androidx.navigation.fragment.findNavController
+import com.example.android.dogsapp.databinding.FragmentFavoritesBinding
+import com.example.android.dogsapp.ui.main.DogClickListener
+import com.example.android.dogsapp.ui.main.DogsAdapter
+import dagger.hilt.android.AndroidEntryPoint
+
+@AndroidEntryPoint
+class FavoritesFragment : Fragment() {
+
+    private lateinit var binding: FragmentFavoritesBinding
+    private val viewModel: FavoritesViewModel by viewModels()
+
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        binding = FragmentFavoritesBinding.inflate(inflater, container, false)
+        binding.lifecycleOwner = viewLifecycleOwner
+        binding.viewModel = viewModel
+
+        val adapter = DogsAdapter(DogClickListener { dog ->
+            viewModel.onDogClicked(dog)
+        })
+        binding.recyclerView.adapter = adapter
+
+        viewModel.favorites.observe(viewLifecycleOwner) {
+            adapter.submitList(it)
+        }
+
+        viewModel.navigateToDetail.observe(viewLifecycleOwner) { dog ->
+            dog?.let {
+                findNavController().navigate(
+                    FavoritesFragmentDirections.actionFavoritesFragmentToDetailsFragment(it)
+                )
+                viewModel.onDogDetailNavigated()
+            }
+        }
+
+        return binding.root
+    }
+}

--- a/app/src/main/java/com/example/android/dogsapp/ui/favorites/FavoritesViewModel.kt
+++ b/app/src/main/java/com/example/android/dogsapp/ui/favorites/FavoritesViewModel.kt
@@ -1,0 +1,32 @@
+package com.example.android.dogsapp.ui.favorites
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.map
+import com.example.android.dogsapp.data.domain.Dog
+import com.example.android.dogsapp.data.repository.DogsRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+@HiltViewModel
+class FavoritesViewModel @Inject constructor(
+    dogsRepository: DogsRepository,
+) : ViewModel() {
+
+    val favorites: LiveData<List<Dog>> = dogsRepository.favorites
+
+    val isEmpty: LiveData<Boolean> = favorites.map { it.isEmpty() }
+
+    private val _navigateToDetail = MutableLiveData<Dog?>()
+    val navigateToDetail: LiveData<Dog?>
+        get() = _navigateToDetail
+
+    fun onDogClicked(dog: Dog) {
+        _navigateToDetail.value = dog
+    }
+
+    fun onDogDetailNavigated() {
+        _navigateToDetail.value = null
+    }
+}

--- a/app/src/main/java/com/example/android/dogsapp/ui/main/MainFragment.kt
+++ b/app/src/main/java/com/example/android/dogsapp/ui/main/MainFragment.kt
@@ -2,11 +2,17 @@ package com.example.android.dogsapp.ui.main
 
 import android.os.Bundle
 import android.view.LayoutInflater
+import android.view.Menu
+import android.view.MenuInflater
+import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
+import androidx.core.view.MenuProvider
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
+import androidx.lifecycle.Lifecycle
 import androidx.navigation.fragment.findNavController
+import com.example.android.dogsapp.R
 import com.example.android.dogsapp.databinding.FragmentMainBinding
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -45,6 +51,21 @@ class MainFragment : Fragment() {
                 viewModel.onDogDetailNavigated()
             }
         }
+
+        requireActivity().addMenuProvider(object : MenuProvider {
+            override fun onCreateMenu(menu: Menu, menuInflater: MenuInflater) {
+                menuInflater.inflate(R.menu.main_menu, menu)
+            }
+
+            override fun onMenuItemSelected(menuItem: MenuItem): Boolean {
+                return if (menuItem.itemId == R.id.action_favorites) {
+                    findNavController().navigate(
+                        MainFragmentDirections.actionMainFragmentToFavoritesFragment()
+                    )
+                    true
+                } else false
+            }
+        }, viewLifecycleOwner, Lifecycle.State.RESUMED)
 
         return binding.root
     }

--- a/app/src/main/res/drawable/ic_favorite_border.xml
+++ b/app/src/main/res/drawable/ic_favorite_border.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="32dp"
+    android:height="32dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorPrimary">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M16.5,3c-1.74,0 -3.41,0.81 -4.5,2.09C10.91,3.81 9.24,3 7.5,3 4.42,3 2,5.42 2,8.5c0,3.78 3.4,6.86 8.55,11.54L12,21.35l1.45,-1.32C18.6,15.36 22,12.28 22,8.5 22,5.42 19.58,3 16.5,3zM12,20.35C7.14,15.71 4,12.85 4,8.5 4,6.5 5.5,5 7.5,5c1.54,0 3.04,0.99 3.57,2.36h1.87C13.46,5.99 14.96,5 16.5,5c2,0 3.5,1.5 3.5,3.5 0,4.35 -3.14,7.21 -8,11.85z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_favorite_filled.xml
+++ b/app/src/main/res/drawable/ic_favorite_filled.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="32dp"
+    android:height="32dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorPrimary">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M12,21.35l-1.45,-1.32C5.4,15.36 2,12.28 2,8.5 2,5.42 4.42,3 7.5,3c1.74,0 3.41,0.81 4.5,2.09C13.09,3.81 14.76,3 16.5,3 19.58,3 22,5.42 22,8.5c0,3.78 -3.4,6.86 -8.55,11.54L12,21.35z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_star.xml
+++ b/app/src/main/res/drawable/ic_star.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="@android:color/white">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M12,17.27L18.18,21l-1.64,-7.03L22,9.24l-7.19,-0.61L12,2 9.19,8.63 2,9.24l5.46,4.73L5.82,21z"/>
+</vector>

--- a/app/src/main/res/layout/fragment_details.xml
+++ b/app/src/main/res/layout/fragment_details.xml
@@ -7,6 +7,9 @@
         <variable
             name="dog"
             type="com.example.android.dogsapp.data.domain.Dog" />
+        <variable
+            name="viewModel"
+            type="com.example.android.dogsapp.ui.details.DetailsViewModel" />
     </data>
 
     <RelativeLayout
@@ -47,6 +50,19 @@
                     android:textAppearance="?attr/textAppearanceHeadline5"
                     app:breedName="@{dog.imageUrl}"
                     tools:text="Breed Name" />
+
+                <ImageView
+                    android:id="@+id/favorite_button"
+                    android:layout_width="48dp"
+                    android:layout_height="48dp"
+                    android:layout_gravity="center_horizontal"
+                    android:layout_marginTop="16dp"
+                    android:background="?attr/selectableItemBackgroundBorderless"
+                    android:contentDescription="@string/favorite"
+                    android:onClick="@{() -> viewModel.toggleFavorite()}"
+                    android:padding="8dp"
+                    app:isFavorite="@{viewModel.isFavorite}"
+                    tools:src="@drawable/ic_favorite_border" />
 
             </LinearLayout>
 

--- a/app/src/main/res/layout/fragment_favorites.xml
+++ b/app/src/main/res/layout/fragment_favorites.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+        <variable
+            name="viewModel"
+            type="com.example.android.dogsapp.ui.favorites.FavoritesViewModel" />
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        tools:context=".ui.favorites.FavoritesFragment">
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/recycler_view"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:clipToPadding="false"
+            android:padding="6dp"
+            app:layoutManager="androidx.recyclerview.widget.GridLayoutManager"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintLeft_toLeftOf="parent"
+            app:layout_constraintRight_toRightOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:listData="@{viewModel.favorites}"
+            app:spanCount="2"
+            tools:itemCount="6"
+            tools:listitem="@layout/grid_view_item" />
+
+        <TextView
+            android:id="@+id/empty_state"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_margin="32dp"
+            android:gravity="center"
+            android:text="@string/no_favorites_yet"
+            android:textAppearance="?attr/textAppearanceBody1"
+            android:visibility="@{viewModel.isEmpty ? android.view.View.VISIBLE : android.view.View.GONE}"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintLeft_toLeftOf="parent"
+            app:layout_constraintRight_toRightOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            tools:visibility="visible" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/app/src/main/res/menu/main_menu.xml
+++ b/app/src/main/res/menu/main_menu.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <item
+        android:id="@+id/action_favorites"
+        android:icon="@drawable/ic_star"
+        android:title="@string/favorites"
+        app:showAsAction="ifRoom" />
+</menu>

--- a/app/src/main/res/navigation/navgraph.xml
+++ b/app/src/main/res/navigation/navgraph.xml
@@ -13,6 +13,9 @@
         <action
             android:id="@+id/action_mainFragment_to_detailsFragment"
             app:destination="@id/detailsFragment" />
+        <action
+            android:id="@+id/action_mainFragment_to_favoritesFragment"
+            app:destination="@id/favoritesFragment" />
     </fragment>
     <fragment
         android:id="@+id/detailsFragment"
@@ -22,5 +25,14 @@
         <argument
             android:name="dog"
             app:argType="com.example.android.dogsapp.data.domain.Dog" />
+    </fragment>
+    <fragment
+        android:id="@+id/favoritesFragment"
+        android:name="com.example.android.dogsapp.ui.favorites.FavoritesFragment"
+        android:label="@string/favorites"
+        tools:layout="@layout/fragment_favorites">
+        <action
+            android:id="@+id/action_favoritesFragment_to_detailsFragment"
+            app:destination="@id/detailsFragment" />
     </fragment>
 </navigation>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2,4 +2,7 @@
     <string name="app_name">Dogs App</string>
     <string name="status">status</string>
     <string name="random_dog_image">Random dog image</string>
+    <string name="favorite">Favorite</string>
+    <string name="favorites">Favorites</string>
+    <string name="no_favorites_yet">No favorites yet — tap the heart on a dog\'s details screen to save it here.</string>
 </resources>

--- a/app/src/test/java/com/example/android/dogsapp/LiveDataTestUtil.kt
+++ b/app/src/test/java/com/example/android/dogsapp/LiveDataTestUtil.kt
@@ -1,0 +1,32 @@
+package com.example.android.dogsapp
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.Observer
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
+
+fun <T> LiveData<T>.getOrAwaitValue(
+    time: Long = 2,
+    timeUnit: TimeUnit = TimeUnit.SECONDS,
+): T {
+    var data: T? = null
+    val latch = CountDownLatch(1)
+    val observer = object : Observer<T> {
+        override fun onChanged(value: T) {
+            data = value
+            latch.countDown()
+            this@getOrAwaitValue.removeObserver(this)
+        }
+    }
+    this.observeForever(observer)
+    try {
+        if (!latch.await(time, timeUnit)) {
+            throw TimeoutException("LiveData value was never set.")
+        }
+    } finally {
+        this.removeObserver(observer)
+    }
+    @Suppress("UNCHECKED_CAST")
+    return data as T
+}

--- a/app/src/test/java/com/example/android/dogsapp/MainDispatcherRule.kt
+++ b/app/src/test/java/com/example/android/dogsapp/MainDispatcherRule.kt
@@ -1,0 +1,17 @@
+package com.example.android.dogsapp
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.rules.TestWatcher
+import org.junit.runner.Description
+
+@kotlinx.coroutines.ExperimentalCoroutinesApi
+class MainDispatcherRule(
+    val testDispatcher: TestDispatcher = UnconfinedTestDispatcher(),
+) : TestWatcher() {
+    override fun starting(description: Description) = Dispatchers.setMain(testDispatcher)
+    override fun finished(description: Description) = Dispatchers.resetMain()
+}

--- a/app/src/test/java/com/example/android/dogsapp/data/repository/DogsRepositoryImplTest.kt
+++ b/app/src/test/java/com/example/android/dogsapp/data/repository/DogsRepositoryImplTest.kt
@@ -1,0 +1,91 @@
+package com.example.android.dogsapp.data.repository
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import com.example.android.dogsapp.data.domain.DogsResponse
+import com.example.android.dogsapp.data.local.FavoriteEntity
+import com.example.android.dogsapp.fakes.FakeDogDao
+import com.example.android.dogsapp.fakes.FakeDogsApi
+import com.example.android.dogsapp.fakes.FakeFavoriteDao
+import com.example.android.dogsapp.getOrAwaitValue
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class DogsRepositoryImplTest {
+
+    @get:Rule
+    val instantTaskExecutorRule = InstantTaskExecutorRule()
+
+    private val url1 = "https://images.dog.ceo/breeds/akita/1.jpg"
+    private val url2 = "https://images.dog.ceo/breeds/beagle/2.jpg"
+
+    @Test
+    fun `dogs maps DAO entities to domain models`() {
+        val dogDao = FakeDogDao()
+        val repo = DogsRepositoryImpl(FakeDogsApi(), dogDao, FakeFavoriteDao())
+
+        runTest { dogDao.insertAll(listOf(com.example.android.dogsapp.data.local.DogEntity(url1))) }
+
+        val dogs = repo.dogs.getOrAwaitValue()
+        assertEquals(1, dogs.size)
+        assertEquals(url1, dogs.first().imageUrl)
+    }
+
+    @Test
+    fun `refresh replaces the cached dogs on success`() = runTest {
+        val dogDao = FakeDogDao()
+        val api = FakeDogsApi(DogsResponse(status = "success", message = listOf(url1, url2)))
+        val repo = DogsRepositoryImpl(api, dogDao, FakeFavoriteDao())
+
+        repo.refresh()
+
+        val dogs = repo.dogs.getOrAwaitValue()
+        assertEquals(listOf(url1, url2), dogs.map { it.imageUrl })
+    }
+
+    @Test
+    fun `refresh throws when api status is not success`() = runTest {
+        val api = FakeDogsApi(DogsResponse(status = "error", message = emptyList()))
+        val repo = DogsRepositoryImpl(api, FakeDogDao(), FakeFavoriteDao())
+
+        assertThrows(IllegalStateException::class.java) {
+            kotlinx.coroutines.runBlocking { repo.refresh() }
+        }
+    }
+
+    @Test
+    fun `toggleFavorite adds when not favorited`() = runTest {
+        val favoriteDao = FakeFavoriteDao()
+        val repo = DogsRepositoryImpl(FakeDogsApi(), FakeDogDao(), favoriteDao)
+
+        repo.toggleFavorite(url1)
+
+        assertTrue(favoriteDao.isFavoriteOnce(url1))
+    }
+
+    @Test
+    fun `toggleFavorite removes when already favorited`() = runTest {
+        val favoriteDao = FakeFavoriteDao(listOf(FavoriteEntity(url1)))
+        val repo = DogsRepositoryImpl(FakeDogsApi(), FakeDogDao(), favoriteDao)
+
+        repo.toggleFavorite(url1)
+
+        assertFalse(favoriteDao.isFavoriteOnce(url1))
+    }
+
+    @Test
+    fun `favorites maps DAO entities to domain models`() {
+        val favoriteDao = FakeFavoriteDao(listOf(FavoriteEntity(url1), FavoriteEntity(url2)))
+        val repo = DogsRepositoryImpl(FakeDogsApi(), FakeDogDao(), favoriteDao)
+
+        val favorites = repo.favorites.getOrAwaitValue()
+
+        assertEquals(listOf(url1, url2), favorites.map { it.imageUrl })
+    }
+}

--- a/app/src/test/java/com/example/android/dogsapp/fakes/FakeDogDao.kt
+++ b/app/src/test/java/com/example/android/dogsapp/fakes/FakeDogDao.kt
@@ -1,0 +1,20 @@
+package com.example.android.dogsapp.fakes
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import com.example.android.dogsapp.data.local.DogDao
+import com.example.android.dogsapp.data.local.DogEntity
+
+class FakeDogDao(initial: List<DogEntity> = emptyList()) : DogDao {
+    private val state = MutableLiveData<List<DogEntity>>(initial)
+
+    override fun observeDogs(): LiveData<List<DogEntity>> = state
+
+    override suspend fun insertAll(dogs: List<DogEntity>) {
+        state.value = (state.value.orEmpty() + dogs).distinctBy { it.imageUrl }
+    }
+
+    override suspend fun clearAll() {
+        state.value = emptyList()
+    }
+}

--- a/app/src/test/java/com/example/android/dogsapp/fakes/FakeDogsApi.kt
+++ b/app/src/test/java/com/example/android/dogsapp/fakes/FakeDogsApi.kt
@@ -1,0 +1,14 @@
+package com.example.android.dogsapp.fakes
+
+import com.example.android.dogsapp.data.domain.DogsResponse
+import com.example.android.dogsapp.data.network.DogsApi
+
+class FakeDogsApi(
+    var response: DogsResponse = DogsResponse(status = "success", message = emptyList()),
+    var error: Throwable? = null,
+) : DogsApi {
+    override suspend fun getRandomDogs(): DogsResponse {
+        error?.let { throw it }
+        return response
+    }
+}

--- a/app/src/test/java/com/example/android/dogsapp/fakes/FakeDogsRepository.kt
+++ b/app/src/test/java/com/example/android/dogsapp/fakes/FakeDogsRepository.kt
@@ -1,0 +1,54 @@
+package com.example.android.dogsapp.fakes
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import com.example.android.dogsapp.data.domain.Dog
+import com.example.android.dogsapp.data.repository.DogsRepository
+
+class FakeDogsRepository(
+    initialDogs: List<Dog> = emptyList(),
+    initialFavorites: List<Dog> = emptyList(),
+) : DogsRepository {
+
+    private val _dogs = MutableLiveData(initialDogs)
+    private val _favorites = MutableLiveData(initialFavorites)
+    private val favoriteLiveData = mutableMapOf<String, MutableLiveData<Boolean>>()
+
+    var refreshError: Throwable? = null
+    var refreshCalls = 0
+        private set
+    var toggleCalls = 0
+        private set
+    val toggledUrls = mutableListOf<String>()
+
+    override val dogs: LiveData<List<Dog>> = _dogs
+    override val favorites: LiveData<List<Dog>> = _favorites
+
+    override fun isFavorite(imageUrl: String): LiveData<Boolean> =
+        favoriteLiveData.getOrPut(imageUrl) {
+            MutableLiveData(_favorites.value.orEmpty().any { it.imageUrl == imageUrl })
+        }
+
+    override suspend fun toggleFavorite(imageUrl: String) {
+        toggleCalls++
+        toggledUrls += imageUrl
+        val current = _favorites.value.orEmpty()
+        _favorites.value =
+            if (current.any { it.imageUrl == imageUrl }) current.filterNot { it.imageUrl == imageUrl }
+            else current + Dog(imageUrl)
+        favoriteLiveData[imageUrl]?.value = _favorites.value.orEmpty().any { it.imageUrl == imageUrl }
+    }
+
+    override suspend fun refresh() {
+        refreshCalls++
+        refreshError?.let { throw it }
+    }
+
+    fun emitDogs(dogs: List<Dog>) {
+        _dogs.value = dogs
+    }
+
+    fun emitFavorites(favorites: List<Dog>) {
+        _favorites.value = favorites
+    }
+}

--- a/app/src/test/java/com/example/android/dogsapp/fakes/FakeFavoriteDao.kt
+++ b/app/src/test/java/com/example/android/dogsapp/fakes/FakeFavoriteDao.kt
@@ -1,0 +1,34 @@
+package com.example.android.dogsapp.fakes
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import com.example.android.dogsapp.data.local.FavoriteDao
+import com.example.android.dogsapp.data.local.FavoriteEntity
+
+class FakeFavoriteDao(initial: List<FavoriteEntity> = emptyList()) : FavoriteDao {
+    private val state = MutableLiveData<List<FavoriteEntity>>(initial)
+    private val perKeyState = mutableMapOf<String, MutableLiveData<Boolean>>()
+
+    override fun observeFavorites(): LiveData<List<FavoriteEntity>> = state
+
+    override fun isFavorite(imageUrl: String): LiveData<Boolean> =
+        perKeyState.getOrPut(imageUrl) {
+            MutableLiveData(state.value.orEmpty().any { it.imageUrl == imageUrl })
+        }
+
+    override suspend fun isFavoriteOnce(imageUrl: String): Boolean =
+        state.value.orEmpty().any { it.imageUrl == imageUrl }
+
+    override suspend fun add(favorite: FavoriteEntity) {
+        val current = state.value.orEmpty()
+        if (current.none { it.imageUrl == favorite.imageUrl }) {
+            state.value = current + favorite
+            perKeyState[favorite.imageUrl]?.value = true
+        }
+    }
+
+    override suspend fun remove(imageUrl: String) {
+        state.value = state.value.orEmpty().filterNot { it.imageUrl == imageUrl }
+        perKeyState[imageUrl]?.value = false
+    }
+}

--- a/app/src/test/java/com/example/android/dogsapp/fakes/FakeRefreshManager.kt
+++ b/app/src/test/java/com/example/android/dogsapp/fakes/FakeRefreshManager.kt
@@ -1,0 +1,13 @@
+package com.example.android.dogsapp.fakes
+
+import com.example.android.dogsapp.ui.utils.RefreshManager
+
+class FakeRefreshManager : RefreshManager {
+    var refreshing: Boolean = false
+        private set
+
+    override fun isRefreshing(): Boolean = refreshing
+    override fun setRefreshing(refreshing: Boolean) { this.refreshing = refreshing }
+    override fun setOnRefreshListener(listener: () -> Unit) = Unit
+    override fun onRefreshTriggered() = Unit
+}

--- a/app/src/test/java/com/example/android/dogsapp/ui/details/DetailsViewModelTest.kt
+++ b/app/src/test/java/com/example/android/dogsapp/ui/details/DetailsViewModelTest.kt
@@ -1,0 +1,58 @@
+package com.example.android.dogsapp.ui.details
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import androidx.lifecycle.SavedStateHandle
+import com.example.android.dogsapp.MainDispatcherRule
+import com.example.android.dogsapp.data.domain.Dog
+import com.example.android.dogsapp.fakes.FakeDogsRepository
+import com.example.android.dogsapp.getOrAwaitValue
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class DetailsViewModelTest {
+
+    @get:Rule val instantTaskExecutorRule = InstantTaskExecutorRule()
+    @get:Rule val mainDispatcherRule = MainDispatcherRule()
+
+    private val dog = Dog("https://images.dog.ceo/breeds/akita/1.jpg")
+    private val savedState = SavedStateHandle(mapOf("dog" to dog))
+
+    @Test
+    fun `dog is read from SavedStateHandle`() {
+        val viewModel = DetailsViewModel(FakeDogsRepository(), savedState)
+        assertEquals(dog, viewModel.dog)
+    }
+
+    @Test
+    fun `isFavorite reflects the repository state`() {
+        val repo = FakeDogsRepository(initialFavorites = listOf(dog))
+        val viewModel = DetailsViewModel(repo, savedState)
+
+        assertEquals(true, viewModel.isFavorite.getOrAwaitValue())
+    }
+
+    @Test
+    fun `toggleFavorite delegates to the repository for the current dog`() {
+        val repo = FakeDogsRepository()
+        val viewModel = DetailsViewModel(repo, savedState)
+
+        viewModel.toggleFavorite()
+
+        assertEquals(1, repo.toggleCalls)
+        assertEquals(listOf(dog.imageUrl), repo.toggledUrls)
+    }
+
+    @Test
+    fun `missing dog nav argument blows up the ViewModel`() {
+        val emptyState = SavedStateHandle()
+        val ex = assertThrows(IllegalStateException::class.java) {
+            DetailsViewModel(FakeDogsRepository(), emptyState)
+        }
+        assertTrue(ex.message?.contains("dog") == true)
+    }
+}

--- a/app/src/test/java/com/example/android/dogsapp/ui/favorites/FavoritesViewModelTest.kt
+++ b/app/src/test/java/com/example/android/dogsapp/ui/favorites/FavoritesViewModelTest.kt
@@ -1,0 +1,51 @@
+package com.example.android.dogsapp.ui.favorites
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import com.example.android.dogsapp.data.domain.Dog
+import com.example.android.dogsapp.fakes.FakeDogsRepository
+import com.example.android.dogsapp.getOrAwaitValue
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Rule
+import org.junit.Test
+
+class FavoritesViewModelTest {
+
+    @get:Rule val instantTaskExecutorRule = InstantTaskExecutorRule()
+
+    private val dogA = Dog("https://images.dog.ceo/breeds/akita/1.jpg")
+    private val dogB = Dog("https://images.dog.ceo/breeds/beagle/2.jpg")
+
+    @Test
+    fun `favorites mirrors the repository`() {
+        val repo = FakeDogsRepository(initialFavorites = listOf(dogA, dogB))
+        val viewModel = FavoritesViewModel(repo)
+
+        assertEquals(listOf(dogA, dogB), viewModel.favorites.getOrAwaitValue())
+    }
+
+    @Test
+    fun `isEmpty is true when there are no favorites`() {
+        val viewModel = FavoritesViewModel(FakeDogsRepository())
+
+        assertEquals(true, viewModel.isEmpty.getOrAwaitValue())
+    }
+
+    @Test
+    fun `isEmpty is false when favorites exist`() {
+        val viewModel = FavoritesViewModel(FakeDogsRepository(initialFavorites = listOf(dogA)))
+
+        assertEquals(false, viewModel.isEmpty.getOrAwaitValue())
+    }
+
+    @Test
+    fun `onDogClicked then onDogDetailNavigated round-trip the navigate state`() {
+        val viewModel = FavoritesViewModel(FakeDogsRepository())
+
+        viewModel.onDogClicked(dogA)
+        assertEquals(dogA, viewModel.navigateToDetail.getOrAwaitValue())
+
+        viewModel.onDogDetailNavigated()
+        assertNull(viewModel.navigateToDetail.getOrAwaitValue())
+    }
+}

--- a/app/src/test/java/com/example/android/dogsapp/ui/main/MainViewModelTest.kt
+++ b/app/src/test/java/com/example/android/dogsapp/ui/main/MainViewModelTest.kt
@@ -1,0 +1,70 @@
+package com.example.android.dogsapp.ui.main
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import com.example.android.dogsapp.MainDispatcherRule
+import com.example.android.dogsapp.data.domain.Dog
+import com.example.android.dogsapp.fakes.FakeDogsRepository
+import com.example.android.dogsapp.fakes.FakeRefreshManager
+import com.example.android.dogsapp.getOrAwaitValue
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Rule
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class MainViewModelTest {
+
+    @get:Rule val instantTaskExecutorRule = InstantTaskExecutorRule()
+    @get:Rule val mainDispatcherRule = MainDispatcherRule()
+
+    private val sampleDog = Dog("https://images.dog.ceo/breeds/akita/1.jpg")
+
+    @Test
+    fun `init triggers refresh and sets status to DONE on success`() {
+        val repo = FakeDogsRepository()
+        val viewModel = MainViewModel(repo, FakeRefreshManager())
+
+        assertEquals(1, repo.refreshCalls)
+        assertEquals(DogsApiStatus.DONE, viewModel.status.getOrAwaitValue())
+    }
+
+    @Test
+    fun `status flips to ERROR when refresh throws`() {
+        val repo = FakeDogsRepository().apply { refreshError = RuntimeException("boom") }
+        val viewModel = MainViewModel(repo, FakeRefreshManager())
+
+        assertEquals(DogsApiStatus.ERROR, viewModel.status.getOrAwaitValue())
+    }
+
+    @Test
+    fun `refreshDogs triggers another refresh and tells refresh manager to stop`() {
+        val repo = FakeDogsRepository()
+        val refreshManager = FakeRefreshManager().apply { setRefreshing(true) }
+        val viewModel = MainViewModel(repo, refreshManager)
+
+        viewModel.refreshDogs()
+
+        assertEquals(2, repo.refreshCalls)
+        assertEquals(false, refreshManager.isRefreshing())
+    }
+
+    @Test
+    fun `dogs LiveData mirrors the repository`() {
+        val repo = FakeDogsRepository(initialDogs = listOf(sampleDog))
+        val viewModel = MainViewModel(repo, FakeRefreshManager())
+
+        assertEquals(listOf(sampleDog), viewModel.dogs.getOrAwaitValue())
+    }
+
+    @Test
+    fun `onDogClicked then onDogDetailNavigated round-trip the navigate state`() {
+        val viewModel = MainViewModel(FakeDogsRepository(), FakeRefreshManager())
+
+        viewModel.onDogClicked(sampleDog)
+        assertEquals(sampleDog, viewModel.navigateToDetail.getOrAwaitValue())
+
+        viewModel.onDogDetailNavigated()
+        assertNull(viewModel.navigateToDetail.getOrAwaitValue())
+    }
+}


### PR DESCRIPTION
## Summary
Closes #14.

- New Room table `favorites` (added via `Migration(1 -> 2)`, so existing cached dogs are preserved).
- `DogsRepository` gains `favorites`, `isFavorite(url)`, and `toggleFavorite(url)`.
- `DetailsFragment` now has a `DetailsViewModel` (Hilt + `SavedStateHandle`) driving a heart toggle in the layout. A new binding adapter swaps filled/border drawables based on `LiveData<Boolean>`.
- `FavoritesFragment` + `FavoritesViewModel` reuse the existing grid + adapter to show favorited dogs. Empty-state copy invites the user to favorite a dog.
- Toolbar gets a star action on the main screen (via `MenuProvider`) that navigates to Favorites.

## Tests
- 19 new unit tests across `DogsRepositoryImpl`, `MainViewModel`, `DetailsViewModel`, `FavoritesViewModel` using in-process fakes for the DAOs/API/repository and `InstantTaskExecutorRule` for LiveData.
- `./gradlew test` passes locally; `./gradlew assembleDebug` passes locally.

## Test plan
- [x] `./gradlew assembleDebug`
- [x] `./gradlew test`
- [ ] Manual: tap heart on details → screen shows filled heart; navigate back, return to details → still filled
- [ ] Manual: refresh main list → favorites screen still shows the previously-favorited dog
- [ ] Manual: kill process, relaunch → favorites persist (Migration 1→2 path)
- [ ] Manual: empty state copy shows on the favorites screen when nothing is favorited

🤖 Generated with [Claude Code](https://claude.com/claude-code)